### PR TITLE
fix printing and setup emacs (basic)

### DIFF
--- a/home/home.nix
+++ b/home/home.nix
@@ -33,6 +33,7 @@
     ouch                 # painless compression and decompression for your terminal
     paprefs              # pulseaudio preferences
     prettyping           # a nicer ping
+    postman              # api testing
     rage                 # encryption tool for secrets management
     spotify              # music streaming
     ripgrep              # fast grep

--- a/home/programs/default.nix
+++ b/home/programs/default.nix
@@ -33,6 +33,7 @@ in [
   ./browser/slack.nix
   ./browser/teams.nix
   ./citrix.nix
+  ./emacs.nix
   ./intellij.nix
   ./git.nix
   ./network.nix

--- a/home/programs/emacs.nix
+++ b/home/programs/emacs.nix
@@ -1,0 +1,13 @@
+{pkgs, ...}: {
+  programs.emacs = {
+    enable = true;
+    package = pkgs.emacs;
+    extraConfig = ''
+      (setq package-archives '(("gnu" . "https://elpa.gnu.org/packages/")
+                               ("melpa" . "https://melpa.org/packages/")))
+      (setq package-check-signature nil)
+      (setq package-enable-at-startup nil)
+      (package-initialize)
+    '';
+  };
+}

--- a/hosts/configuration.nix
+++ b/hosts/configuration.nix
@@ -42,6 +42,8 @@
   # Add dconf settings
   programs.dconf.enable = true;
   services = {
+    printing.enable = true; # Enable CUPS to print documents.
+    # Enable the X11 windowing system.
     xserver = {
       videoDrivers = ["intel"];
       displayManager = {

--- a/hosts/system/desktop/gnome.nix
+++ b/hosts/system/desktop/gnome.nix
@@ -31,7 +31,6 @@
 
   # Systray Icons
   environment.systemPackages = with pkgs; [
-    gnomeExtensions.appindicator
     gnomeExtensions.vitals
     gnomeExtensions.tiling-assistant
     gnomeExtensions.user-themes


### PR DESCRIPTION
Printing was not enabled for cups, fixed as a service.
Add Postman to packages.
Add emacs and basic setup for development