### PR TITLE
Setup luks crypt

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,6 +4,8 @@ DEVICE_NAME="/dev/nvme0n1"
 EFI_SIZE="512MiB"
 SWAP_SIZE="9.1GiB"
 LABEL_NAME="NIXOS"
+CRYPTROOT_NAME="cryptroot"
+CRYPTSWAP_NAME="cryptswap"
 
 function create_partitions {
   #Create partitions
@@ -20,16 +22,28 @@ function create_partitions {
   lsblk
 }
 
+function setup_luks {
+  # Encrypt the root partition
+  cryptsetup --verify-passphrase -v luksFormat "${DEVICE_NAME}p3"
+  cryptsetup open "${DEVICE_NAME}p3" "${CRYPTROOT_NAME}"
+
+  # Encrypt the swap partition
+  cryptsetup --verify-passphrase -v luksFormat "${DEVICE_NAME}p2"
+  cryptsetup open "${DEVICE_NAME}p2" "${CRYPTSWAP_NAME}"
+
+  echo "LUKS setup completed"
+}
+
 function mount_partitions {
   # Format Partitions
   mkfs.fat -F32 -n EFI "${DEVICE_NAME}p1"
-  mkswap -L SWAP "${DEVICE_NAME}p2"
-  mkfs.btrfs -L "${LABEL_NAME}" -f "${DEVICE_NAME}p3"
+  mkswap -L SWAP "/dev/mapper/${CRYPTSWAP_NAME}"
+  mkfs.btrfs -L "${LABEL_NAME}" -f "/dev/mapper/${CRYPTROOT_NAME}"
 
   echo "Partitions formatted"
 
   # Mount partitions
-  mount "${DEVICE_NAME}p3" /mnt
+  mount "/dev/mapper/${CRYPTROOT_NAME}" /mnt
 
   btrfs subvolume create /mnt/root
   btrfs subvolume create /mnt/home
@@ -38,21 +52,23 @@ function mount_partitions {
   btrfs subvolume create /mnt/tmp
 
   umount /mnt
-  mount -o noatime,compress=zstd,ssd,space_cache=v2,subvol=root "${DEVICE_NAME}p3" /mnt
+  mount -o noatime,compress=zstd,ssd,space_cache=v2,subvol=root "/dev/mapper/${CRYPTROOT_NAME}" /mnt
 
   mkdir -p /mnt/{boot/efi,home,tmp,nix,var}
-  mount -o noatime,compress=zstd,ssd,space_cache=v2,subvol=home "${DEVICE_NAME}p3" /mnt/home
-  mount -o noatime,compress=zstd,ssd,space_cache=v2,subvol=nix "${DEVICE_NAME}p3" /mnt/nix
-  mount -o noatime,compress=zstd,ssd,space_cache=v2,subvol=var "${DEVICE_NAME}p3" /mnt/var
-  mount -o noatime,compress=zstd,ssd,space_cache=v2,subvol=tmp "${DEVICE_NAME}p3" /mnt/tmp
+  mount -o noatime,compress=zstd,ssd,space_cache=v2,subvol=home "/dev/mapper/${CRYPTROOT_NAME}" /mnt/home
+  mount -o noatime,compress=zstd,ssd,space_cache=v2,subvol=nix "/dev/mapper/${CRYPTROOT_NAME}" /mnt/nix
+  mount -o noatime,compress=zstd,ssd,space_cache=v2,subvol=var "/dev/mapper/${CRYPTROOT_NAME}" /mnt/var
+  mount -o noatime,compress=zstd,ssd,space_cache=v2,subvol=tmp "/dev/mapper/${CRYPTROOT_NAME}" /mnt/tmp
 
   mount "${DEVICE_NAME}p1" /mnt/boot/efi
-  swapon "${DEVICE_NAME}p2"
+  swapon "/dev/mapper/${CRYPTSWAP_NAME}"
 
   clear
   df -Th
   free -h
+  echo "Run: nixos-install --flake .#yourhostname"
 }
 
 create_partitions
+setup_luks
 mount_partitions

--- a/system/hardware/boot.nix
+++ b/system/hardware/boot.nix
@@ -16,6 +16,15 @@
     initrd = {
       availableKernelModules = [ "xhci_pci" "thunderbolt" "vmd" "nvme" "usb_storage" "sd_mod" ];
       kernelModules = [ ];
+      luks.devices = {
+        cryptroot = {
+          device = "/dev/nvme0n1p3";
+          preLVM = true;
+        };
+        cryptswap = {
+          device = "/dev/nvme0n1p2";
+        };
+      };
     };
     kernelModules = [
       "kvm-intel"

--- a/system/hardware/disk.nix
+++ b/system/hardware/disk.nix
@@ -1,31 +1,31 @@
 {
   fileSystems = {
     "/" = {
-      device = "/dev/nvme0n1p3";
+      device = "/dev/mapper/cryptroot";
       fsType = "btrfs";
       options = [ "subvol=root" "noatime" "compress=zstd" "ssd" ];
     };
 
     "/home" = {
-      device = "/dev/nvme0n1p3";
+      device = "/dev/mapper/cryptroot";
       fsType = "btrfs";
       options = [ "subvol=home" "noatime" "compress=zstd" "ssd" ];
     };
 
     "/nix" = {
-      device = "/dev/nvme0n1p3";
+      device = "/dev/mapper/cryptroot";
       fsType = "btrfs";
       options = [ "subvol=nix" "noatime" "compress=zstd" "ssd" ];
     };
 
     "/var" = {
-      device = "/dev/nvme0n1p3";
+      device = "/dev/mapper/cryptroot";
       fsType = "btrfs";
       options = [ "subvol=var" "noatime" "compress=zstd" "ssd" ];
     };
 
     "/tmp" = {
-      device = "/dev/nvme0n1p3";
+      device = "/dev/mapper/cryptroot";
       fsType = "btrfs";
       options = [ "subvol=tmp" "noatime" "compress=zstd" "ssd" ];
     };
@@ -37,6 +37,6 @@
   };
 
   swapDevices = [
-    { device = "/dev/nvme0n1p2"; }
+    { device = "/dev/mapper/cryptswap"; }
   ];
 }


### PR DESCRIPTION
# Description

## To be implemented summer 2025

This pull request introduces changes to add LUKS encryption for the root and swap partitions in the NixOS setup script and corresponding configuration files. The most important changes include adding new functions and modifying existing ones to support encrypted partitions.

Encryption setup:

* [`scripts/setup.sh`](diffhunk://#diff-ce435f38623d032d25670f2c63a430dfd1a02db661d10c1ef031cbef2f0f0ef0R7-R8): Added `CRYPTROOT_NAME` and `CRYPTSWAP_NAME` variables to store the names of the encrypted root and swap partitions.
* [`scripts/setup.sh`](diffhunk://#diff-ce435f38623d032d25670f2c63a430dfd1a02db661d10c1ef031cbef2f0f0ef0R25-R46): Introduced the `setup_luks` function to handle the encryption of the root and swap partitions using LUKS.

Partition mounting:

* [`scripts/setup.sh`](diffhunk://#diff-ce435f38623d032d25670f2c63a430dfd1a02db661d10c1ef031cbef2f0f0ef0L41-R73): Updated the `mount_partitions` function to format and mount the encrypted partitions instead of the raw device partitions.


NB! Will require a new install.